### PR TITLE
Allow usage of free DeepL API (different base URL)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - [Markus Mattes](https://github.com/mmattes)
 - [Patrick Beer](https://github.com/vandebeer)
 - [jcmag](https://github.com/jcmag)
+- [Michal Cadecky](https://github.com/MichalCadecky)

--- a/source/DeepL/DeepLClient.cs
+++ b/source/DeepL/DeepLClient.cs
@@ -31,6 +31,7 @@ namespace DeepL
         /// Initializes a new <see cref="DeepLClient"/> instance.
         /// </summary>
         /// <param name="authenticationKey">The authentication key for the DeepL API.</param>
+        /// <param name="isFree">Flag to determine if free version of DeepL API should be used</param>
         public DeepLClient(string authenticationKey, bool isFree = false)
         {
             this.authenticationKey = authenticationKey;

--- a/source/DeepL/DeepLClient.cs
+++ b/source/DeepL/DeepLClient.cs
@@ -31,9 +31,10 @@ namespace DeepL
         /// Initializes a new <see cref="DeepLClient"/> instance.
         /// </summary>
         /// <param name="authenticationKey">The authentication key for the DeepL API.</param>
-        public DeepLClient(string authenticationKey)
+        public DeepLClient(string authenticationKey, bool isFree = false)
         {
             this.authenticationKey = authenticationKey;
+            this.isFree = isFree;
 
             this.httpClient = new HttpClient();
             this.httpClient.DefaultRequestHeaders.Add("User-Agent", $"DeepL.NET/{Assembly.GetExecutingAssembly().GetName().Version}");
@@ -47,9 +48,14 @@ namespace DeepL
         #region Private Static Fields
 
         /// <summary>
-        /// Contains the DeepL API base URL.
+        /// Contains the DeepL API Pro base URL.
         /// </summary>
         private static readonly string baseUrl = "https://api.deepl.com/v2";
+
+        /// <summary>
+        /// Contains the DeepL API Free base URL.
+        /// </summary>
+        private static readonly string baseFreeUrl = "https://api-free.deepl.com/v2";
 
         /// <summary>
         /// Contains the path to the action that retrieves usage statistics from the API.
@@ -151,6 +157,11 @@ namespace DeepL
         private readonly string authenticationKey;
 
         /// <summary>
+        /// Determines which url should be used for DeepL API.
+        /// </summary>
+        private readonly bool isFree;
+
+        /// <summary>
         /// Contains an HTTP client, which is used to call the DeepL API.
         /// </summary>
         private readonly HttpClient httpClient;
@@ -195,7 +206,7 @@ namespace DeepL
                 throw new ArgumentException("The path must not be empty.");
 
             // Concatenates the path to the base URL
-            string url = $"{DeepLClient.baseUrl}/{path}";
+            string url = $"{(this.isFree ? DeepLClient.baseFreeUrl : DeepLClient.baseUrl)}/{path}";
 
             // Adds the path parameters
             if (pathParameters != null && pathParameters.Any())

--- a/source/DeepL/DeepLClient.cs
+++ b/source/DeepL/DeepLClient.cs
@@ -31,11 +31,11 @@ namespace DeepL
         /// Initializes a new <see cref="DeepLClient"/> instance.
         /// </summary>
         /// <param name="authenticationKey">The authentication key for the DeepL API.</param>
-        /// <param name="isFree">Flag to determine if free version of DeepL API should be used</param>
-        public DeepLClient(string authenticationKey, bool isFree = false)
+        /// <param name="useFreeApi">Flag to determine if free version of DeepL API should be used</param>
+        public DeepLClient(string authenticationKey, bool useFreeApi = false)
         {
             this.authenticationKey = authenticationKey;
-            this.isFree = isFree;
+            this.useFreeApi = useFreeApi;
 
             this.httpClient = new HttpClient();
             this.httpClient.DefaultRequestHeaders.Add("User-Agent", $"DeepL.NET/{Assembly.GetExecutingAssembly().GetName().Version}");
@@ -51,12 +51,12 @@ namespace DeepL
         /// <summary>
         /// Contains the DeepL API Pro base URL.
         /// </summary>
-        private static readonly string baseUrl = "https://api.deepl.com/v2";
+        private static readonly string proApiBaseUrl = "https://api.deepl.com/v2";
 
         /// <summary>
         /// Contains the DeepL API Free base URL.
         /// </summary>
-        private static readonly string baseFreeUrl = "https://api-free.deepl.com/v2";
+        private static readonly string freeApiBaseUrl = "https://api-free.deepl.com/v2";
 
         /// <summary>
         /// Contains the path to the action that retrieves usage statistics from the API.
@@ -160,7 +160,7 @@ namespace DeepL
         /// <summary>
         /// Determines which url should be used for DeepL API.
         /// </summary>
-        private readonly bool isFree;
+        private readonly bool useFreeApi;
 
         /// <summary>
         /// Contains an HTTP client, which is used to call the DeepL API.
@@ -207,7 +207,7 @@ namespace DeepL
                 throw new ArgumentException("The path must not be empty.");
 
             // Concatenates the path to the base URL
-            string url = $"{(this.isFree ? DeepLClient.baseFreeUrl : DeepLClient.baseUrl)}/{path}";
+            string url = $"{(this.useFreeApi ? DeepLClient.freeApiBaseUrl : DeepLClient.proApiBaseUrl)}/{path}";
 
             // Adds the path parameters
             if (pathParameters != null && pathParameters.Any())


### PR DESCRIPTION
First of all I'm sorry to start already with fork - I have read the contribution notice after I had been done with the change :/ Although the change is very trivial. There is already a pull request with similiar idea #8 but my approach is slightly different and I think it is better aligned with the original idea of keeping the `baseUrl` readonly.

If there is anything I could improve, please let me know.